### PR TITLE
Use fzf-tmux command only if available

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -9,8 +9,9 @@ from prompt_toolkit.keys import Keys
 __all__ = ()
 
 def get_fzf_binary_name():
-    if 'TMUX' in ${...}:
-        return 'fzf-tmux'
+    fzf_tmux_cmd = 'fzf-tmux'
+    if 'TMUX' in ${...} and $(which fzf_tmux_cmd):
+        return fzf_tmux_cmd
     return 'fzf'
 
 

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -6,7 +6,7 @@ from xonsh.completers.path import complete_path
 from xonsh.platform import ptk_shell_type
 from prompt_toolkit.keys import Keys
 
-__all__ = ()
+__all__ = ['Keys']
 
 def get_fzf_binary_name():
     fzf_tmux_cmd = 'fzf-tmux'


### PR DESCRIPTION
Use `fzf` if `fzf-tmux` is not available.