### PR TITLE
Add fzf-z widget

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,10 @@ Current widgets
 - **find directory:** Similar to the previous one, but intended to only search for directories.
 - **z:** Search the combination of (displayed in this order):
 
-  - Any paths listed in a 'bookmark' file located at `$SHELL_BOOKMARKS` (defaults to `~/.shell_bookmarks`)
-  - The output of `z -l .`, if `xontrib-z <https://github.com/astronouth7303/xontrib-z>`_ is loaded.
+  - Any paths listed in a 'bookmark' file located at ``$SHELL_BOOKMARKS`` (defaults to ``~/.shell_bookmarks``)
+  - The output of ``z -l .``, if `xontrib-z <https://github.com/astronouth7303/xontrib-z>`_ is loaded.
 
-  This widget is loosely based on the `fzf-z plugin <https://github.com/andrewferrier/fzf-z>`_ for `zsh`.
+  This widget is loosely based on the `fzf-z plugin <https://github.com/andrewferrier/fzf-z>`_ for ``zsh``.
 
 
 How to use it

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,13 @@ Current widgets
 - **history insert:** Search in all history entries and insert the chosen command to the prompt.
 - **find file:** Find one or more files in the current directory and its sub-directories.
 - **find directory:** Similar to the previous one, but intended to only search for directories.
+- **z:** Search the combination of (displayed in this order):
+
+  - Any paths listed in a 'bookmark' file located at `$SHELL_BOOKMARKS` (defaults to `~/.shell_bookmarks`)
+  - The output of `z -l .`, if `xontrib-z <https://github.com/astronouth7303/xontrib-z>`_ is loaded.
+
+  This widget is loosely based on the `fzf-z plugin <https://github.com/andrewferrier/fzf-z>`_ for `zsh`.
+
 
 How to use it
 ----------------
@@ -49,6 +56,7 @@ And set your desired keybindings for each widget in `~/.xonshrc` file or set it 
     $fzf_ssh_binding = "c-s"      # Ctrl+S
     $fzf_file_binding = "c-t"      # Ctrl+T
     $fzf_dir_binding = "c-g"      # Ctrl+G
+    $fzf_z_binding = "c-p"      # Ctrl+P
 
 You can find the names of various keys here_ in ``python-prompt-toolkit``.
 

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -134,6 +134,9 @@ def custom_keybindings(bindings, **kw):
 
     @handler('fzf_z_binding')
     def fzf_z(event):
+
+        current_dir_listing = '\n'.join(os.listdir())
+
         bookmarks = Path(
             __xonsh__.env.get(
                 "SHELL_BOOKMARKS",
@@ -143,17 +146,18 @@ def custom_keybindings(bindings, **kw):
 
         if bookmarks.is_file():
             with open(bookmarks, "r") as f:
-                bookmark_items = f.read()
+                bookmark_items = f.read().rstrip()
         else:
             bookmark_items = ""
 
         try:
-            z_items = xontrib.z.ZHandler.handler(['-l', ''])
+            z_items = xontrib.z.ZHandler.handler(["-l", ""])
         except AttributeError:
-            z_items = ''
+            z_items = ""
 
-        items = bookmark_items + z_items
+        items = "\n".join([current_dir_listing, bookmark_items, z_items])
 
         choice = fzf_prompt_from_string(items)
-        event.cli.renderer.erase()
-        event.current_buffer.insert_text(f"'{choice}'")
+        if choice:
+            event.cli.renderer.erase()
+            event.current_buffer.insert_text(f"'{choice}'")

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -6,7 +6,13 @@ from xonsh.completers.path import complete_path
 from prompt_toolkit.keys import Keys
 from pathlib import Path
 from xonsh import built_ins
+from prompt_toolkit.application.current import get_app
 import xontrib
+try:
+    from xonsh.ptk.key_bindings import carriage_return
+except ImportError:
+    from xonsh.ptk_shell.key_bindings import carriage_return
+
 
 __all__ = ()
 
@@ -143,6 +149,7 @@ def custom_keybindings(bindings, **kw):
     def fzf_dir(event):
         fzf_insert_file(event, True)
 
+
     @handler('fzf_z_binding')
     def fzf_z(event):
 
@@ -190,7 +197,8 @@ def custom_keybindings(bindings, **kw):
             event.current_buffer.document.cursor_position == 0 and
             os.path.isdir(choice)
         ):
-            xonsh.built_ins.cd([choice])
+            built_ins.builtins.aliases['cd']([choice])
+            carriage_return(event.current_buffer, event.cli)
             return
 
         event.current_buffer.insert_text(f"'{choice}'")

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -4,6 +4,7 @@ import subprocess
 from xonsh.history.main import history_main
 from xonsh.completers.path import complete_path
 from prompt_toolkit.keys import Keys
+import xontrib
 
 __all__ = ()
 
@@ -130,3 +131,29 @@ def custom_keybindings(bindings, **kw):
     @handler('fzf_dir_binding')
     def fzf_dir(event):
         fzf_insert_file(event, True)
+
+    @handler('fzf_z_binding')
+    def fzf_z(event):
+        bookmarks = Path(
+            __xonsh__.env.get(
+                "SHELL_BOOKMARKS",
+                os.path.expanduser("~/.shell_bookmarks")
+            )
+        )
+
+        if bookmarks.is_file():
+            with open(bookmarks, "r") as f:
+                bookmark_items = f.read()
+        else:
+            bookmark_items = ""
+
+        try:
+            z_items = xontrib.z.ZHandler.handler(['-l', ''])
+        except AttributeError:
+            z_items = ''
+
+        items = bookmark_items + z_items
+
+        choice = fzf_prompt_from_string(items)
+        event.cli.renderer.erase()
+        event.current_buffer.insert_text(f"'{choice}'")

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -7,6 +7,7 @@ from prompt_toolkit.keys import Keys
 from pathlib import Path
 from xonsh import built_ins
 from prompt_toolkit.application.current import get_app
+from xonsh.xoreutils.which import which
 import xontrib
 try:
     from xonsh.ptk.key_bindings import carriage_return
@@ -173,7 +174,27 @@ def custom_keybindings(bindings, **kw):
 
         items = "\n".join(bookmark_items + z_items)
 
-        args = [get_fzf_binary_path(),'--tiebreak=index', '+m', '--reverse', '--height=40%']
+        args = [
+            get_fzf_binary_path(),
+            '--tiebreak=index',
+            '+m',
+            '--reverse',
+            '--height=40%',
+        ]
+        # Preview command
+        if not which(['exa']):
+            args += [
+                "--preview",
+                "![test -d {}] and exa --level 2 --tree --color=always --group-directories-first {}"
+            ]
+        if not which(['tree']):
+            args += [
+                '--preview',
+                "![test -d {}] and tree -C -L 2 -x --noreport --dirsfirst {}"
+            ]
+        else:
+            args += ["--preview", "ls -l {}"]
+
         prefix = get_cursor_prefix(event)
         if prefix:
             args.append(f'-q {prefix}')

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -136,7 +136,7 @@ def custom_keybindings(bindings, **kw):
     @handler('fzf_z_binding')
     def fzf_z(event):
 
-        current_dir_listing = '\n'.join(os.listdir())
+        current_dir_listing = os.listdir()
 
         bookmarks = Path(
             __xonsh__.env.get(
@@ -147,16 +147,16 @@ def custom_keybindings(bindings, **kw):
 
         if bookmarks.is_file():
             with open(bookmarks, "r") as f:
-                bookmark_items = f.read().rstrip()
+                bookmark_items = [_.rstrip() for _ in f]
         else:
-            bookmark_items = ""
+            bookmark_items = []
 
         try:
-            z_items = xontrib.z.ZHandler.handler(["-l", ""])
+            z_items = xontrib.z.ZHandler.handler(["-l", ""]).splitlines()
         except AttributeError:
-            z_items = ""
+            z_items = []
 
-        items = "\n".join([current_dir_listing, bookmark_items, z_items])
+        items = "\n".join(current_dir_listing + bookmark_items + z_items)
 
         choice = fzf_prompt_from_string(items)
 

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -136,8 +136,6 @@ def custom_keybindings(bindings, **kw):
     @handler('fzf_z_binding')
     def fzf_z(event):
 
-        current_dir_listing = os.listdir()
-
         bookmarks = Path(
             __xonsh__.env.get(
                 "SHELL_BOOKMARKS",
@@ -156,7 +154,7 @@ def custom_keybindings(bindings, **kw):
         except AttributeError:
             z_items = []
 
-        items = "\n".join(current_dir_listing + bookmark_items + z_items)
+        items = "\n".join(bookmark_items + z_items)
 
         choice = fzf_prompt_from_string(items)
 

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -158,6 +158,9 @@ def custom_keybindings(bindings, **kw):
         items = "\n".join([current_dir_listing, bookmark_items, z_items])
 
         choice = fzf_prompt_from_string(items)
+
+        # Redraw the shell because fzf used alternate mode
+        event.cli.renderer.erase()
+
         if choice:
-            event.cli.renderer.erase()
             event.current_buffer.insert_text(f"'{choice}'")

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -4,6 +4,7 @@ import subprocess
 from xonsh.history.main import history_main
 from xonsh.completers.path import complete_path
 from prompt_toolkit.keys import Keys
+from pathlib import Path
 import xontrib
 
 __all__ = ()


### PR DESCRIPTION
Hi,

Thanks for maintaining this `xontrib`, great to see the subprocess workaround for using `fzf` with `xonsh`!

This PR adds a new widget that searches the combination of (displayed in this order):
- The file/dir listing under the working directory
- Any paths listed in a 'bookmark' file located at `$SHELL_BOOKMARKS` (defaults to `~/.shell_bookmarks`)
- The output of [`z -l .`](https://github.com/astronouth7303/xontrib-z). 

It is loosely based on the [`fzf-z`](https://github.com/andrewferrier/fzf-z) plugin for `zsh`.

It might be too subjective, based on my needs, so let me know if you think the widget would be better served as a dedicated xontrib.

Will add to the readme if you think it would make a nice addition!