### PR TITLE
Replace grep with re.findall

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -110,7 +110,11 @@ def custom_keybindings(bindings, **kw):
 
     @handler('fzf_ssh_binding')
     def fzf_ssh(event):
-        items = re.sub(r'(?i)host ', '', $(cat ~/.ssh/config /etc/ssh/ssh_config | grep -i '^host'))
+        items = '\n'.join(
+             re.findall(r'Host\s(.*)\n?',
+                        $(cat ~/.ssh/config /etc/ssh/ssh_config),
+                        re.IGNORECASE)
+        )
         choice = fzf_prompt_from_string(items)
 
         # Redraw the shell because fzf used alternate mode


### PR DESCRIPTION
Hey,

Capturing the output of `grep` in `fzf_ssh` results in the reported [back cursor issue](https://github.com/xonsh/xonsh/issues/3491). Here's my `xonfig` if you're curious:
```
+------------------+-----------------+
| xonsh            | 0.9.18          |
| Python           | 3.8.3           |
| PLY              | 3.11            |
| have readline    | True            |
| prompt toolkit   | 3.0.5           |
| shell type       | prompt_toolkit  |
| pygments         | 2.6.1           |
| on posix         | True            |
| on linux         | True            |
| distro           | unknown         |
| on darwin        | False           |
| on windows       | False           |
| on cygwin        | False           |
| on msys2         | False           |
| is superuser     | False           |
| default encoding | utf-8           |
| xonsh encoding   | utf-8           |
| encoding errors  | surrogateescape |
+------------------+-----------------+
```
To get around this, this PR proposes `re.findall` to filter the host names of the ssh configs.