### PR TITLE
Move cursor to end of text on history insert

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -41,6 +41,7 @@ def fzf_insert_history(event):
 
     if choice:
         event.current_buffer.text = choice
+        event.current_buffer.cursor_position = len(choice)
 
 
 def fzf_insert_file(event, dirs_only=False):


### PR DESCRIPTION
fzf in other shells moves the cursor to the end of the selected text when inserting from history. This replicates that behaviour.