### PR TITLE
features: read also hosts from ~/.ssh/known_hosts; auto-ssh if buffer is empty

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -120,18 +120,24 @@ def custom_keybindings(bindings, **kw):
 
     @handler('fzf_ssh_binding')
     def fzf_ssh(event):
-        items = '\n'.join(
-             re.findall(r'Host\s(.*)\n?',
-                        $(cat ~/.ssh/config /etc/ssh/ssh_config),
-                        re.IGNORECASE)
-        )
-        choice = fzf_prompt_from_string(items)
+        choice = fzf_prompt_from_string(_hosts_from_config() + _hosts_from_known_hosts())
 
         # Redraw the shell because fzf used alternate mode
         event.cli.renderer.erase()
 
+
         if choice:
             event.current_buffer.insert_text('ssh ' + choice)
+
+    def _hosts_from_config():
+        return '\n'.join(
+            re.findall(r'Host\s(.*)\n?',
+                       $(cat ~/.ssh/config /etc/ssh/ssh_config),
+                       re.IGNORECASE)
+        )
+
+    def _hosts_from_known_hosts():
+        return $(cat ~/.ssh/known_hosts | awk '{ split($1, A, ","); print(A[1]) }')
 
     @handler('fzf_file_binding')
     def fzf_file(event):

--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -127,7 +127,12 @@ def custom_keybindings(bindings, **kw):
 
 
         if choice:
-            event.current_buffer.insert_text('ssh ' + choice)
+            cmd = 'ssh ' + choice
+            should_eval = event.current_buffer.document.cursor_position == 0
+            event.current_buffer.insert_text(cmd)
+            if should_eval:
+                event.current_buffer.validate_and_handle()
+                event.cli.renderer.erase()
 
     def _hosts_from_config():
         return '\n'.join(


### PR DESCRIPTION
Hey, 

I have SSH configured to apply certain settings on whole domains (e.g. `*.scoiatael.dev`), so config doesn't list any hosts explicitly. `known_hosts`, on the other hand, has a complete list of all hosts I have ever SSH'd into - so it looks like a viable place for getting suggestions. 

Unless you have hashing enabled, of course. But this should be a sane default for most people :)
