### PR TITLE
Fix: Use copy of os.environ to avoid mutating env

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -71,7 +71,7 @@ def fzf_insert_file(event, dirs_only=False):
                 cwd = os.getcwd()
                 os.chdir(expanded_path)
 
-    env = os.environ
+    env = dict(os.environ)
     if dirs_only:
         if 'fzf_find_dirs_command' in ${...}:
             env['FZF_DEFAULT_COMMAND'] = $fzf_find_dirs_command


### PR DESCRIPTION
Hi! Thanks for maintaining this, it's quite useful.

I found that the xontrib modifies environment variables in a way that is probably not desired. 

I set my $FZF_DEFAULT_OPTS to the following:
```
$FZF_DEFAULT_OPTS="-m --reverse --height=40 --preview 'bat --color=always --style=numbers --line-range=:500 {}'"
```
This uses [`bat`](https://github.com/sharkdp/bat) to display a nice file preview:

![image](https://user-images.githubusercontent.com/3419601/136113539-e3237d25-0c3d-451a-a9ae-e4760ab773da.png)

The issue is that in a xonsh session, after using the file searcher (which modifies `$FZF_DEFAULT_OPTS` to include the default args), the args are carried over to the command history search. It then tries to fetch a preview for commands, which doesn't work, and I imagine could lead to unintended commands being run.

This PR modifies the code to use `dict(os.environ)` instead of `os.environ` directly, so that we can modify a copy without affecting env vars. Although `os.environ` is its own class and not a dict, `subprocess.run` takes a mapping as per [the documentation](https://docs.python.org/3/library/subprocess.html#subprocess.run):
> If env is not None, it must be a mapping that defines the environment variables for the new process

And I've tested this to verify it now works as expected.