### PR TITLE
fix: in TMUX context, fzf (not fzf-tmux) is found.

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -9,7 +9,7 @@ __all__ = ()
 
 def get_fzf_binary_name():
     fzf_tmux_cmd = 'fzf-tmux'
-    if 'TMUX' in ${...} and $(which fzf_tmux_cmd):
+    if 'TMUX' in ${...} and $(which @(fzf_tmux_cmd)):
         return fzf_tmux_cmd
     return 'fzf'
 


### PR DESCRIPTION
we have : 
```
$ def get_fzf_binary_name():
.     fzf_tmux_cmd = 'fzf-tmux'
.     if 'TMUX' in ${...} and $(which fzf_tmux_cmd):
.         return fzf_tmux_cmd
.
.     return 'fzf'
.                 
[11:02:21]  fuzzy@fricadin ~  [no k8s context]
$ get_fzf_binary_name() 
fzf_tmux_cmd not in $PATH or xonsh.builtins.aliases
'fzf'
```

we want : 
```
$ def get_fzf_binary_name():
.     fzf_tmux_cmd = 'fzf-tmux'
.     if 'TMUX' in ${...} and $(which @(fzf_tmux_cmd)):
.         return fzf_tmux_cmd
.
.     return 'fzf'
.                 
[10:59:39]  fuzzy@fricadin ~  [no k8s context]
$ get_fzf_binary_name()
'fzf-tmux'
```